### PR TITLE
chore: adding workflow to create releases

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -1,0 +1,68 @@
+---
+name: Create tag & release
+run-name: Create tag & release
+description: Create a new tag and release when a PR is merged to main (release/*)
+# yamllint disable-line rule:truthy
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+permissions:
+  contents: write
+jobs:
+  create_release:
+    if: >
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main' &&
+      startsWith(github.event.pull_request.head.ref, 'release/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main branch
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+      - name: Get the version
+        id: get_version
+        run: |
+          NEW_TAG=$(cat .version)
+          PREVIOUS_TAG=$(git describe --tags --abbrev=0)
+          echo "NEW_TAG=${NEW_TAG}" >> ${GITHUB_ENV}
+          echo "PREVIOUS_TAG=${PREVIOUS_TAG}" >> ${GITHUB_ENV}
+      - name: Create the new tag
+        id: create_tag
+        run: |
+          git config --global user.email "release-bot@open-metadata.org"
+          git config --global user.name "OpenMetadata Release Bot"
+          git tag -a ${{ env.NEW_TAG }} -m "Release version ${{ env.NEW_TAG }}"
+          git push origin ${{ env.NEW_TAG }}
+      - name: Create the release body
+        id: create_release_body
+        run: |
+          function create_release_body() {
+            if [[ $# -ne 3 ]]; then
+              echo "Usage: create_release_body <previous_tag> <new_tag> <repo_url>"
+              return 1
+            fi
+            local PREVIOUS_TAG=${1}
+            local NEW_TAG=${2}
+            local REPO_URL=${3}
+            local DATE=$(date +%Y-%m-%d)
+            local RELEASE_BODY_FILE="/tmp/body.md"
+            local REPO_URL="https://github.com/${{ github.repository }}"
+            cat > ${RELEASE_BODY_FILE} <<-EOF
+          ## [${NEW_TAG}](${REPO_URL}/compare/${PREVIOUS_TAG}...${NEW_TAG}) (${DATE})
+
+          ### Features
+          * Bump OpenMetadata version to ${NEW_TAG}
+          EOF
+            cat ${RELEASE_BODY_FILE}
+            echo "RELEASE_BODY_FILE=${RELEASE_BODY_FILE}" >> ${GITHUB_ENV}
+          }
+          create_release_body "${{ env.PREVIOUS_TAG}}" "${{ env.NEW_TAG }}" "${{ env.REPO_URL }}"
+      - name: Create the new release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.NEW_TAG }}
+          body_path: ${{ env.RELEASE_BODY_FILE }}


### PR DESCRIPTION
This workflow is triggered when a pull request is closed. If the PR was merged into the `main` branch and the source branch matches the pattern `release/*`, it will:

* Create a new tag based on the version specified in the `.version` file.
* Create a new GitHub release using the newly created tag.
