### PR TITLE
fix:align IAM IRSA module and AWS provider with v6

### DIFF
--- a/examples/complete/ebs_csi_driver.tf
+++ b/examples/complete/ebs_csi_driver.tf
@@ -3,7 +3,7 @@
 resource "aws_eks_addon" "ebs_csi_driver" {
   cluster_name                = local.eks_cluster_name
   addon_name                  = "aws-ebs-csi-driver"
-  service_account_role_arn    = module.ebs_csi_irsa.iam_role_arn
+  service_account_role_arn    = module.ebs_csi_irsa.arn
   resolve_conflicts_on_create = "OVERWRITE"
   resolve_conflicts_on_update = "OVERWRITE"
   depends_on = [
@@ -13,9 +13,10 @@ resource "aws_eks_addon" "ebs_csi_driver" {
 }
 
 module "ebs_csi_irsa" {
-  source = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
+  version = "~> 6.0"
 
-  role_name             = "ebs-csi"
+  name                  = "ebs-csi"
   attach_ebs_csi_policy = true
 
   oidc_providers = {

--- a/examples/complete/efs_csi_driver.tf
+++ b/examples/complete/efs_csi_driver.tf
@@ -4,7 +4,7 @@
 resource "aws_eks_addon" "efs_csi_driver" {
   cluster_name             = local.eks_cluster_name
   addon_name               = "aws-efs-csi-driver"
-  service_account_role_arn = module.efs_csi_irsa.iam_role_arn
+  service_account_role_arn = module.efs_csi_irsa.arn
   depends_on = [
     module.efs_csi_irsa,
     aws_eks_node_group.nodes
@@ -12,9 +12,10 @@ resource "aws_eks_addon" "efs_csi_driver" {
 }
 
 module "efs_csi_irsa" {
-  source = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
+  version = "~> 6.0"
 
-  role_name             = "efs-csi"
+  name                  = "efs-csi"
   attach_efs_csi_policy = true
 
   oidc_providers = {

--- a/examples/complete/providers.tf
+++ b/examples/complete/providers.tf
@@ -21,10 +21,10 @@ provider "kubernetes" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = aws_eks_cluster.openmetadata.endpoint
     cluster_ca_certificate = base64decode(aws_eks_cluster.openmetadata.certificate_authority[0].data)
-    exec {
+    exec = {
       api_version = "client.authentication.k8s.io/v1beta1"
       args        = ["eks", "get-token", "--cluster-name", var.eks_cluster_name, "--region", var.region]
       command     = "aws"

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
 }


### PR DESCRIPTION
## Describe your changes:

- **IAM IRSA (EBS/EFS CSI):** Switched from `terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks `(removed in IAM module v6) to `//modules/iam-role-for-service-accounts `with `version = "~> 6.0"`, updated inputs/outputs to match v6 (role_name → name, iam_role_arn → arn).
- **AWS provider**: Bumped hashicorp/aws in `examples/complete/versions.tf` from `~> 5.0 to ~> 6.0` so constraints align with IAM v6 and the OpenMetadata module (resolves conflicting ~> 5.0 vs ~> 6.0 during terraform init).
- **Helm provider:** In `examples/complete/providers.tf `(lines 23–33), replaced the invalid nested `kubernetes { ... } `block with the object form `kubernetes = { ... }` (and nested exec as an object), which matches the Helm provider schema and fixes Unsupported block type on terraform plan.

Fixes #77 

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on these changes because terraform init failed (missing IAM submodule + AWS provider constraint clash) and terraform plan failed with an unsupported kubernetes block in the Helm provider after upgrading/using a current Helm provider version.

## Motivation and Context

The registry IAM module v6 no longer ships iam-role-for-service-accounts-eks, and it requires AWS provider 6.x. The example still pinned AWS 5.x, so Terraform could not select any provider version. 
Separately, the Helm provider expects kubernetes as a map/object argument, not a nested block.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
No change to the published OpenMetadata module API. The complete example now assumes hashicorp/aws ~> 6.0 and a Helm provider that uses the kubernetes = { ... } attribute style; stacks that copied the old example may need the same provider updates.

<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
Validated with terraform init in examples/complete after the IAM and AWS provider updates, and terraform plan after the Helm kubernetes configuration fix.
